### PR TITLE
Headers should not be converted a second time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,36 +20,36 @@ $ npm install -D json-caching-proxy
 
   Options:
 
-    -h, --help             output usage information
-    -V, --version          output the version number
-    -c, --config [path]    load a config file of options. Command line args will be overridden
-    -u, --url [url]        remote server (e.g. https://network:8080)
-    -p, --port [number]    port for the local proxy server
-    -hf, --har [path]      load entries from a HAR file and hydrate the cache
-    -b, --bust [list]      a list of cache busting query params to ignore. (e.g. -b _:time:dc)
-    -e, --exclude [regex]  exclude specific routes from cache, (e.g. --exclude "GET /api/keep-alive/.*")
-    -a, --all              cache everything from the remote server (Default is to cache just JSON responses)
-    -dp, --playback        disables cache playback
-    -dr, --record          disables recording to cache
-    -cp, --prefix          change the prefix for the proxy's web admin endpoints
-    -phi, --header         change the response header property for identifying cached responses
-    -l, --log              print log output to console
+    -h, --help                output usage information
+    -V, --version             output the version number
+    -c, --config [path]       load a config file of options. Command line args will be overridden
+    -u, --url [url]           remote server (e.g. https://network:8080)
+    -p, --port [number]       port for the local proxy server
+    -H, --har [path]          load entries from a HAR file and hydrate the cache
+    -b, --bust [list]         a list of cache busting query params to ignore. (e.g. --bust _:cacheSlayer:time:dc)
+    -e, --exclude [regex]     exclude specific routes from cache, (e.g. --exclude "GET /api/keep-alive/.*")
+    -a, --all                 cache everything from the remote server (Default is to cache just JSON responses)
+    -P, --disablePlayback     disables cache playback
+    -R, --disableRecord       disables recording to cache
+    -C, --cmdPrefix [prefix]  change the prefix for the proxy's web admin endpoints
+    -I, --header [header]     change the response header property for identifying cached responses
+    -l, --log                 print log output to console
 ```
 
 #### Example - basic JSON caching with output
 ```
-$ json-caching-proxy -u http://remote:8080 -p 3001 -l
+$ json-caching-proxy -u http://remote:8080 -l
 ```
 
 #### Example - hydrating the cache
 You may have a HAR file that was generated elsewhere (e.g. Chrome Developer tools). You can load this file and initialize the cache
 ```
-$ json-caching-proxy -u http://remote:8080 -p 3001 -hf chromeDevTools.har -l
+$ json-caching-proxy -u http://remote:8080 -p 3001 -H chromeDevTools.har -l
 ```
 
 #### Example - advanced arguments
 ```
-$ json-caching-proxy -u http://remote:8080 -p 3001 -b time:dc -e '/keepalive' -h hydrate.har -a -l
+$ json-caching-proxy -u http://remote:8080 -p 3001 -b time:dc -e '/keepalive' -H hydrate.har -a -l
 ```
 
 * Routes requests to `http://remote:8080`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install -D json-caching-proxy
     -c, --config [path]    load a config file of options. Command line args will be overridden
     -u, --url [url]        remote server (e.g. https://network:8080)
     -p, --port [number]    port for the local proxy server
-    -h, --har [path]       load entries from a HAR file and hydrate the cache
+    -hf, --har [path]      load entries from a HAR file and hydrate the cache
     -b, --bust [list]      a list of cache busting query params to ignore. (e.g. -b _:time:dc)
     -e, --exclude [regex]  exclude specific routes from cache, (e.g. --exclude "GET /api/keep-alive/.*")
     -a, --all              cache everything from the remote server (Default is to cache just JSON responses)
@@ -41,7 +41,13 @@ $ npm install -D json-caching-proxy
 $ json-caching-proxy -u http://remote:8080 -p 3001 -l
 ```
 
-#### Example - further cmd arguments
+#### Example - hydrating the cache
+You may have a HAR file that was generated elsewhere (e.g. Chrome Developer tools). You can load this file and initialize the cache
+```
+$ json-caching-proxy -u http://remote:8080 -p 3001 -hf chromeDevTools.har -l
+```
+
+#### Example - advanced arguments
 ```
 $ json-caching-proxy -u http://remote:8080 -p 3001 -b time:dc -e '/keepalive' -h hydrate.har -a -l
 ```
@@ -206,8 +212,8 @@ Once the proxy has started, you may point your browser to the following urls to 
 ```
 http://localhost:3001/proxy/playback?enabled=[true|false] - Start/Stop replaying cached requests.
 http://localhost:3001/proxy/record?enabled=[true|false] - Start/Stop recording request/responses to the cache.
+http://localhost:3001/proxy/har - Download cache to json-caching-proxy.har
 http://localhost:3001/proxy/clear - Empty the in-memory cache.
-http://localhost:3001/proxy/har - Download the cache to json-caching-proxy.har
 ```
 
 ## License

--- a/bin.js
+++ b/bin.js
@@ -28,7 +28,7 @@ program
 	.option('-c, --config [path]', 'load a config file of options. Command line args will be overridden')
 	.option('-u, --url [url]', 'remote server (e.g. https://network:8080)')
 	.option('-p, --port [number]', 'port for the local proxy server', parseInt)
-	.option('-h, --har [path]', 'load entries from a HAR file and hydrate the cache')
+	.option('-hf, --har [path]', 'load entries from a HAR file and hydrate the cache')
 	.option('-b, --bust [list]', 'a list of cache busting query params to ignore. (e.g. --bust _:cacheSlayer:time:dc)', list)
 	.option('-e, --exclude [regex]', 'exclude specific routes from cache, (e.g. --exclude "GET /api/keep-alive/.*")')
 	.option('-a, --all', 'cache everything from the remote server (Default is to cache just JSON responses)')

--- a/bin.js
+++ b/bin.js
@@ -15,12 +15,8 @@ function list (val) {
 	return val.split(':').map(item => item.trim());
 }
 
-// Get a default value
-function def (valToCheck, defaultVal, isBoolean=true) {
-	if (typeof valToCheck !== 'undefined') {
-		return isBoolean ? !!valToCheck : valToCheck;
-	}
-	return defaultVal;
+function isDef (val) {
+	return typeof val !== 'undefined';
 }
 
 program
@@ -28,14 +24,14 @@ program
 	.option('-c, --config [path]', 'load a config file of options. Command line args will be overridden')
 	.option('-u, --url [url]', 'remote server (e.g. https://network:8080)')
 	.option('-p, --port [number]', 'port for the local proxy server', parseInt)
-	.option('-hf, --har [path]', 'load entries from a HAR file and hydrate the cache')
+	.option('-H, --har [path]', 'load entries from a HAR file and hydrate the cache')
 	.option('-b, --bust [list]', 'a list of cache busting query params to ignore. (e.g. --bust _:cacheSlayer:time:dc)', list)
 	.option('-e, --exclude [regex]', 'exclude specific routes from cache, (e.g. --exclude "GET /api/keep-alive/.*")')
 	.option('-a, --all', 'cache everything from the remote server (Default is to cache just JSON responses)')
-	.option('-dp, --playback', 'disables cache playback')
-	.option('-dr, --record', 'disables recording to cache')
-	.option('-cp, --prefix', 'change the prefix for the proxy\'s web admin endpoints')
-	.option('-phi, --header', 'change the response header property for identifying cached responses')
+	.option('-P, --disablePlayback', 'disables cache playback')
+	.option('-R, --disableRecord', 'disables recording to cache')
+	.option('-C, --cmdPrefix [prefix]', 'change the prefix for the proxy\'s web admin endpoints')
+	.option('-I, --header [header]', 'change the response header property for identifying cached responses')
 	.option('-l, --log', 'print log output to console')
 	.parse(process.argv);
 
@@ -61,12 +57,13 @@ if (!remoteServerUrl) {
 let proxyPort = configOptions.proxyPort ? parseInt(configOptions.proxyPort, 10) : program.port;
 let inputHarFile = configOptions.inputHarFile || program.har;
 let cacheBustingParams = configOptions.cacheBustingParams ? configOptions.cacheBustingParams : program.bust;
-let cacheEverything = def(configOptions.cacheEverything, def(program.all, false));
-let dataPlayback = def(configOptions.dataPlayback, def(program.playback, true));
-let dataRecord = def(configOptions.dataRecord, def(program.record, true));
-let showConsoleOutput = def(configOptions.showConsoleOutput, def(program.log, false));
-let commandPrefix = configOptions.commandPrefix || program.prefix;
+let commandPrefix = configOptions.commandPrefix || program.cmdPrefix;
 let proxyHeaderIdentifier = configOptions.proxyHeaderIdentifier || program.header;
+let cacheEverything = isDef(configOptions.cacheEverything) ? configOptions.cacheEverything : isDef(program.all) ? program.all : false;
+let dataPlayback = isDef(configOptions.dataPlayback) ? configOptions.dataPlayback : isDef(program.disablePlayback) ? !program.disablePlayback : true;
+let dataRecord = isDef(configOptions.dataRecord) ? configOptions.dataRecord : isDef(program.disableRecord) ? !program.disableRecord : true;
+let showConsoleOutput = isDef(configOptions.showConsoleOutput) ? configOptions.showConsoleOutput : isDef(program.log) ? program.log : false;
+
 
 let excludedRouteMatchers;
 if (configOptions.excludedRouteMatchers && configOptions.excludedRouteMatchers.length > 0) {
@@ -78,7 +75,7 @@ if (configOptions.excludedRouteMatchers && configOptions.excludedRouteMatchers.l
 let harObject;
 if (inputHarFile) {
 	try {
-		let filePath = path.isAbsolute(program.config) ? program.config : path.join(cwd, inputHarFile);
+		let filePath = path.isAbsolute(inputHarFile) ? inputHarFile : path.join(cwd, inputHarFile);
 		harObject = JSON.parse(fs.readFileSync(filePath, "utf8"));
 	} catch (err) {
 		console.error('Could not read har file', err.path);

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ class JsonCachingProxy {
 
 					if (entry.response.headers && (this.options.cacheEverything || !this.options.cacheEverything && mimeType && mimeType.indexOf('application/json') >= 0)) {
 						// Remove content-encoding. gzip compression won't be used
-						entry.response.headers = this.convertToNameValueList(entry.response.headers).filter(header => header.name.toLowerCase() !== 'content-encoding');
+					entry.response.headers = entry.response.headers.filter(header => header.name.toLowerCase() !== 'content-encoding');
 						this.routeCache[key] = entry;
 
 						this.log(chalk.yellow('Saved to Cache', hash, chalk.bold(entry.request.method, entry.request.url)));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-caching-proxy",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "in-memory caching proxy",
   "keywords": [
     "cache",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-caching-proxy",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "in-memory caching proxy",
   "keywords": [
     "cache",

--- a/test/config.json
+++ b/test/config.json
@@ -5,9 +5,9 @@
 */
 
 {
-  "remoteServerUrl": "http://wikimapia.org",
+  "remoteServerUrl": "http://52.205.63.7:8080",
   "proxyPort": 3001,
-  "inputHarFile": "./test/test.har",
+  "inputHarFile": "test.har",
   "cacheEverything": true,
   "cacheBustingParams": ["_", "dc", "cacheSlayer"],
   "excludedRouteMatchers": ["/*.js", "/*.png"],

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,3 @@
-// This has to be the last require or else the fs is screwed up
-
 const util = require('util');
 const assert = require('assert');
 const fetch = require('node-fetch');


### PR DESCRIPTION
When saving the headers, there is no need to convert the list, otherwise we end up setting them like that on the client: 
```
{
  0: [Object object]
}
```