### PR TITLE
Secure attribute fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,8 +64,6 @@ class JsonCachingProxy {
 			let cookieParts = c.split(';');
 			let newCookieParts = [];
 
-      console.log(cookieParts);
-
 			cookieParts.forEach(c => {
 				if (c.indexOf('domain') === -1 && c.indexOf('secure') === -1) {
 					newCookieParts.push(c);

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class JsonCachingProxy {
 	}
 
 	/**
-	* Remove the domain portion of any cookies from the object
+	* Remove the domain portion of any cookies from the object. Remove the secure attribute so we can set cookies to https targets
 	* @param {Object} cookies - Express cookies array
 	* @returns {Object[]} - Cookies with domain portion removed
 	*/
@@ -64,10 +64,12 @@ class JsonCachingProxy {
 			let cookieParts = c.split(';');
 			let newCookieParts = [];
 
+      console.log(cookieParts);
+
 			cookieParts.forEach(c => {
-				if (c.indexOf('domain') === -1) {
+				if (c.indexOf('domain') === -1 && c.indexOf('secure') === -1) {
 					newCookieParts.push(c);
-				}
+        }
 			});
 
 			return newCookieParts.join(';');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-caching-proxy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "in-memory reverse caching proxy",
   "keywords": [
     "cache",


### PR DESCRIPTION
Remove secure attribute from cookies so that the proxy can pass cookies along to the browser from https targets